### PR TITLE
Allow boolean type as function arguments.

### DIFF
--- a/lib/slate/parser/extensions.rb
+++ b/lib/slate/parser/extensions.rb
@@ -6,6 +6,18 @@ module Slate
       end
     end
 
+    class True < Treetop::Runtime::SyntaxNode
+      def text_value
+        true
+      end
+    end
+
+    class False < Treetop::Runtime::SyntaxNode
+      def text_value
+        false
+      end
+    end
+
     class Function < Treetop::Runtime::SyntaxNode
       def text_value
         elements.detect{ |e| e.is_a? Token }.text_value

--- a/lib/slate/parser/slate_tree.treetop
+++ b/lib/slate/parser/slate_tree.treetop
@@ -4,6 +4,18 @@ module Slate
       (target / space)*
     end
 
+    rule true
+      'true' <True>
+    end
+
+    rule false
+      'false' <False>
+    end
+
+    rule boolean
+      true / false
+    end
+
     rule target
       space? string space '{' space? function* space? '}' <Target>
     end
@@ -13,11 +25,11 @@ module Slate
     end
 
     rule argument
-      (string / integer) ','? space? <Argument>
+      (boolean / string / integer) ','? space? <Argument>
     end
 
     rule token
-      [a-zA-Z]+ <Token>
+      !boolean [a-zA-Z]+ <Token>
     end
 
     rule string

--- a/lib/slate/target.rb
+++ b/lib/slate/target.rb
@@ -43,6 +43,8 @@ module Slate
       args.map do |arg|
         if arg.is_a?(Numeric)
           arg.to_s
+        elsif arg == true || arg == false
+            arg.to_s
         elsif arg.is_a? Slate::Target
           arg.to_s
         else

--- a/spec/lib/slate/parser_spec.rb
+++ b/spec/lib/slate/parser_spec.rb
@@ -59,12 +59,12 @@ describe Slate::Parser do
 
   it "should be able to parse a target with one function and multiple args" do
     target = Slate::Target.build("stats.web01.response_time") do |t|
-      t.add_function :summarize, "5min", "avg"
+      t.add_function :summarize, "5min", "avg", true
     end
 
     Slate::Parser.parse(%q{
       "stats.web01.response_time" {
-        summarize "5min", "avg"
+        summarize "5min", "avg", true
       }
     }).to_s.should == target.to_s
   end
@@ -72,13 +72,13 @@ describe Slate::Parser do
   it "should be able to parse a target with multiple functions" do
     target = Slate::Target.build("stats.web01.response_time") do |t|
       t.add_function :sum
-      t.add_function :summarize, "5min", "avg"
+      t.add_function :summarize, "5min", "avg", false
     end
 
     Slate::Parser.parse(%q{
       "stats.web01.response_time" {
         sum
-        summarize "5min", "avg"
+        summarize "5min", "avg", false
       }
     }).to_s.should == target.to_s
   end

--- a/spec/lib/slate/target_spec.rb
+++ b/spec/lib/slate/target_spec.rb
@@ -42,6 +42,20 @@ describe Slate::Target do
       end
     end
 
+    context "with a boolean as a function argument" do
+      it "should add the arguments with false" do
+        target.add_function :summarize, "1h", "avg", false
+
+        target.to_s.should == "summarize(some.target,\"1h\",\"avg\",false)"
+      end
+
+      it "should add the arguments with true" do
+        target.add_function :summarize, "1h", "avg", true
+
+        target.to_s.should == "summarize(some.target,\"1h\",\"avg\",true)"
+      end
+    end
+
     context "with a number as a function argument" do
       it "should add an argument" do
         target.add_function :aliasByNode, 1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require "cgi"
 
 RSpec.configure do |config|
   # Use color in STDOUT
-  config.color_enabled = true
+  config.color = true
 
   # Use color not only in STDOUT but also in pagers and files
   config.tty = true


### PR DESCRIPTION
Graphite actually has various functions that take boolean type as an argument.  For example: 
http://graphite-api.readthedocs.io/en/latest/functions.html#graphite_api.functions.summarize.  This patch enables boolean type to be parsed correctly without the quotes.